### PR TITLE
feat(ban): Add temporary ban functionality and database sqlite

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .env
 dump-dir
 .qodo
+db/*.sqlite

--- a/db/db_bot.go
+++ b/db/db_bot.go
@@ -1,0 +1,93 @@
+package db
+
+import (
+	"database/sql"
+	"log"
+	"time"
+
+	_ "github.com/mattn/go-sqlite3"
+)
+
+var DB *sql.DB
+
+func InitDB() error {
+	var err error
+	DB, err = sql.Open("sqlite3", "db/databot.sqlite")
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	_, err = DB.Exec(`
+		CREATE TABLE IF NOT EXISTS tempbans (
+			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			user_id TEXT NOT NULL,
+			guild_id TEXT NOT NULL,
+			ban_start TEXT NOT NULL,
+			ban_end TEXT,
+			reason TEXT,
+			banned_by TEXT NOT NULL
+		)
+	`)
+	if err != nil {
+		log.Fatal(err)
+	}
+	return nil
+}
+
+func AddTempBan(userID, guildID, bannedBy string, duration time.Duration, reason string) error {
+	banStart := time.Now().UTC().Format(time.RFC3339)
+	var banEnd string
+	if duration > 0 {
+		banEnd = time.Now().Add(duration).UTC().Format(time.RFC3339)
+	}
+
+	_, err := DB.Exec(`
+        INSERT INTO tempbans (user_id, guild_id, ban_start, ban_end, reason, banned_by)
+        VALUES (?,?,?,?,?,?)
+	`, userID, guildID, banStart, banEnd, reason, bannedBy)
+
+	if err != nil {
+		log.Printf("Error adding ban: %v", err)
+	} else {
+		log.Printf("Add ban for user %s in guild %s until %v", userID, guildID, banEnd)
+	}
+	return err
+}
+
+func GetExpiredBans() ([]struct {
+	UserID  string
+	GuildID string
+}, error) {
+	now := time.Now().UTC().Format(time.RFC3339)
+	rows, err := DB.Query(`
+        SELECT user_id, guild_id
+        FROM tempbans
+	    WHERE ban_end IS NOT NULL AND ban_end <= ?
+	`, now)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var expiredBans []struct {
+		UserID  string
+		GuildID string
+	}
+
+	for rows.Next() {
+		var ban struct {
+			UserID  string
+			GuildID string
+		}
+		if err := rows.Scan(&ban.UserID, &ban.GuildID); err != nil {
+			return nil, err
+		}
+		expiredBans = append(expiredBans, ban)
+	}
+	return expiredBans, nil
+}
+
+func RemoveTempBans(userID string) error {
+	_, err := DB.Exec("DELETE FROM tempbans WHERE user_id = ?", userID)
+	return err
+}

--- a/go.mod
+++ b/go.mod
@@ -20,6 +20,7 @@ require (
 	github.com/googleapis/enterprise-certificate-proxy v0.3.4 // indirect
 	github.com/googleapis/gax-go/v2 v2.14.1 // indirect
 	github.com/gorilla/websocket v1.5.3 // indirect
+	github.com/mattn/go-sqlite3 v1.14.24 // indirect
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.58.0 // indirect
 	go.opentelemetry.io/otel v1.34.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -32,6 +32,8 @@ github.com/gorilla/websocket v1.5.3 h1:saDtZ6Pbx/0u+bgYQ3q96pZgCzfhKXGPqt7kZ72aN
 github.com/gorilla/websocket v1.5.3/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/joho/godotenv v1.5.1 h1:7eLL/+HRGLY0ldzfGMeQkb7vMd0as4CfYvUVzLqw0N0=
 github.com/joho/godotenv v1.5.1/go.mod h1:f4LDr5Voq0i2e/R5DDNOoa2zzDfwtkZa6DnEwAbqwq4=
+github.com/mattn/go-sqlite3 v1.14.24 h1:tpSp2G2KyMnnQu99ngJ47EIkWVmliIizyZBfPrBWDRM=
+github.com/mattn/go-sqlite3 v1.14.24/go.mod h1:Uh1q+B4BYcTPb+yiD3kU8Ct7aC0hY9fxUwlHK0RXw+Y=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=

--- a/main.go
+++ b/main.go
@@ -160,7 +160,10 @@ func banDatabaseTicker(s *discordgo.Session) {
 			} else {
 				log.Printf("Unbanned user %s from guild %s", ban.UserID, ban.GuildID)
 			}
-			db.RemoveTempBans(ban.UserID)
+			err = db.RemoveTempBans(ban.UserID)
+			if err != nil {
+				log.Printf("Error removing temporary ban for user %s: %v", ban.UserID, err)
+			}
 		}
 	}
 }

--- a/slashcommands/ban_unban.go
+++ b/slashcommands/ban_unban.go
@@ -2,18 +2,22 @@ package slashcommands
 
 import (
 	"fmt"
+	"log"
 	"time"
 
 	"github.com/bwmarrin/discordgo"
+
+	"kings-bot/db"
 )
 
+// variable used across the package
 var (
-	defaultPerms    int64 = discordgo.PermissionBanMembers
-	defaultDM             = false
+	defaultPerms    int64 = discordgo.PermissionBanMembers // Minimum permission required
+	defaultDM             = false                          // disable command in DM
 	banLogChannelID string
 )
 
-// UnbanCommand Variable for Unban Command
+// UnbanCommand : Represents the Discord application command for unban functionality
 var UnbanCommand = &discordgo.ApplicationCommand{
 	Name:        "unban",
 	Description: "Unban user",
@@ -31,21 +35,24 @@ var UnbanCommand = &discordgo.ApplicationCommand{
 			Required:    true,
 		},
 	},
-	DefaultMemberPermissions: &defaultPerms,
-	DMPermission:             &defaultDM,
+	DefaultMemberPermissions: &defaultPerms, // User must have permission to ban member
+	DMPermission:             &defaultDM,    // Disable command in DM
 }
 
+// Init the ban log channel
 func Init(logChannelID string) {
 	banLogChannelID = logChannelID
 }
 
-// UnbanhandlerCommand Function to handle Unban Command
+// UnbanhandlerCommand : Handle the unban command invoke by user
 func UnbanhandlerCommand(s *discordgo.Session, i *discordgo.InteractionCreate) {
+	// Check permission or required role
 	if !hasRequiredRole(s, i.GuildID, i.Member) {
 		respondWithError(s, i, "You dont have permission to use this command")
 		return
 	}
 
+	// Extract command option
 	options := i.ApplicationCommandData().Options
 	userID := options[0].StringValue()
 	reason := options[1].StringValue()
@@ -54,7 +61,7 @@ func UnbanhandlerCommand(s *discordgo.Session, i *discordgo.InteractionCreate) {
 		reason = options[1].StringValue()
 	}
 
-	// Check if the user is actually banned
+	// Check if the user is still banned
 	bans, err := s.GuildBans(i.GuildID, 1000, "", "")
 	if err != nil {
 		respondWithError(s, i, fmt.Sprintf("Failed to retrieve ban list: %v", err))
@@ -74,12 +81,13 @@ func UnbanhandlerCommand(s *discordgo.Session, i *discordgo.InteractionCreate) {
 		return
 	}
 
-	err = s.GuildBanDelete(i.GuildID, userID)
+	err = s.GuildBanDelete(i.GuildID, userID) // Remove the ban
 	if err != nil {
 		respondWithError(s, i, fmt.Sprintf("Failed to unban user: %v", err))
 		return
 	}
 
+	// Embed message for confirmation unban
 	embed := &discordgo.MessageEmbed{
 		Title: "User Unbanned",
 		Color: 0x00ff00,
@@ -106,6 +114,7 @@ func UnbanhandlerCommand(s *discordgo.Session, i *discordgo.InteractionCreate) {
 		},
 	}
 
+	// Send respond confirmation for successful unban command
 	err = s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
 		Type: discordgo.InteractionResponseChannelMessageWithSource,
 		Data: &discordgo.InteractionResponseData{
@@ -117,6 +126,7 @@ func UnbanhandlerCommand(s *discordgo.Session, i *discordgo.InteractionCreate) {
 	}
 }
 
+// Check if member has required MOD role
 func hasRequiredRole(s *discordgo.Session, guildID string, member *discordgo.Member) bool {
 	for _, roleID := range member.Roles {
 		role, err := s.State.Role(guildID, roleID)
@@ -130,12 +140,13 @@ func hasRequiredRole(s *discordgo.Session, guildID string, member *discordgo.Mem
 	return false
 }
 
+// Send ephemeral error message in response to a slash command
 func respondWithError(s *discordgo.Session, i *discordgo.InteractionCreate, message string) {
 	err := s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
 		Type: discordgo.InteractionResponseChannelMessageWithSource,
 		Data: &discordgo.InteractionResponseData{
 			Content: message,
-			Flags:   discordgo.MessageFlagsEphemeral,
+			Flags:   discordgo.MessageFlagsEphemeral, // Hide message from other user
 		},
 	})
 	if err != nil {
@@ -143,7 +154,7 @@ func respondWithError(s *discordgo.Session, i *discordgo.InteractionCreate, mess
 	}
 }
 
-// BanCommand variable for Ban Command
+// BanCommand : variable for discord bot command ban functionality
 var BanCommand = &discordgo.ApplicationCommand{
 	Name:        "ban",
 	Description: "Ban user",
@@ -157,10 +168,10 @@ var BanCommand = &discordgo.ApplicationCommand{
 		{
 			Type:        discordgo.ApplicationCommandOptionInteger,
 			Name:        "time",
-			Description: "Ban duration in hours (0 for permanent ban)",
+			Description: "Ban duration in hours (0 for perma), max 720hr(30d)",
 			Required:    true,
-			MinValue:    &[]float64{0}[0],
-			MaxValue:    720,
+			MinValue:    &[]float64{0}[0], // Minimum duration 0 for perma ban
+			MaxValue:    720,              // Max 30D ban
 		},
 		{
 			Type:        discordgo.ApplicationCommandOptionString,
@@ -168,16 +179,27 @@ var BanCommand = &discordgo.ApplicationCommand{
 			Description: "Insert Reason",
 			Required:    false,
 		},
+		{
+			Type:        discordgo.ApplicationCommandOptionInteger,
+			Name:        "delmsg",
+			Description: "Delete old message (0-7)",
+			Required:    false,
+			MinValue:    &[]float64{0}[0],
+			MaxValue:    7,
+		},
 	},
-	DefaultMemberPermissions: &defaultPerms,
-	DMPermission:             &defaultDM,
+	DefaultMemberPermissions: &defaultPerms, // Require ban permission role
+	DMPermission:             &defaultDM,    // Disable command in DM
 }
 
+// Fetch banned user information (username)
 func getBannedUserInfo(s *discordgo.Session, userID string) (*discordgo.User, error) {
 	return s.User(userID)
 }
 
+// BanhandlerCommand : Handle the ban command when invoke by user
 func BanhandlerCommand(s *discordgo.Session, i *discordgo.InteractionCreate) {
+	// Check permission or required role
 	if !hasRequiredRole(s, i.GuildID, i.Member) {
 		respondWithError(s, i, "You dont have permission to use this command")
 		return
@@ -185,37 +207,51 @@ func BanhandlerCommand(s *discordgo.Session, i *discordgo.InteractionCreate) {
 
 	options := i.ApplicationCommandData().Options
 	userID := options[0].StringValue()
-	bandurationHours := options[1].IntValue()
+	banDurationHours := options[1].IntValue()
 
 	var reason string
 	if len(options) > 2 {
 		reason = options[2].StringValue()
 	}
 
-	banDurationDays := int(bandurationHours / 24)
-	if bandurationHours%24 != 0 {
-		banDurationDays++
+	var deleteMsgDays int
+	if len(options) > 3 {
+		deleteMsgDays = int(options[3].IntValue())
 	}
 
-	err := s.GuildBanCreateWithReason(i.GuildID, userID, reason, banDurationDays)
+	// Calculate number of days
+	banDuration := time.Duration(banDurationHours) * time.Minute
+
+	// Ban the user
+	err := s.GuildBanCreateWithReason(i.GuildID, userID, reason, deleteMsgDays)
 	if err != nil {
 		respondWithError(s, i, fmt.Sprintf("Failed to ban user: %v", err))
 		return
 	}
 
-	var durationString string
-	if bandurationHours == 0 {
-		durationString = "permanently"
-	} else {
-		durationString = fmt.Sprintf("%d Hours", bandurationHours)
+	if banDurationHours > 0 {
+		err = db.AddTempBan(userID, i.GuildID, i.Member.User.ID, banDuration, reason)
+		if err != nil {
+			log.Printf("Error adding temporary ban to database: %v", err)
+		}
 	}
 
+	// Determine ban duration string
+	var durationString string
+	if banDurationHours == 0 {
+		durationString = "permanently"
+	} else {
+		durationString = fmt.Sprintf("%d Hours", banDurationHours)
+	}
+
+	// Fetch banned username for log message
 	bannedUsername, err := getBannedUserInfo(s, userID)
 	if err != nil {
 		respondWithError(s, i, fmt.Sprintf("Failed to retrieve banned user info: %v", err))
 		return
 	}
 
+	// Create ember for log message
 	logEmbed := &discordgo.MessageEmbed{
 		Title: "User Banned by MOD",
 		Color: 0xff0000,
@@ -249,12 +285,14 @@ func BanhandlerCommand(s *discordgo.Session, i *discordgo.InteractionCreate) {
 		Timestamp: time.Now().Format(time.RFC3339),
 	}
 
+	// Send ban log to specific channel
 	_, err = s.ChannelMessageSendEmbed(banLogChannelID, logEmbed)
 	if err != nil {
 		respondWithError(s, i, fmt.Sprintf("Failed to send log message: %v", err))
 		return
 	}
 
+	// Send ban confirmation message to user
 	message := fmt.Sprintf("User %s banned for %s. Reason: %s", userID, durationString, reason)
 	err = s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
 		Type: discordgo.InteractionResponseChannelMessageWithSource,


### PR DESCRIPTION
- Implemented a new temporary ban feature that allows mods to ban users for a specified duration.
- Integrated a SQLite database to store the ban information, including the user ID, ban duration, and expiration timestamp.
- Added necessary database schema and queries to manage the temporary bans.